### PR TITLE
Make basicOperatorMap private

### DIFF
--- a/filter/converter.go
+++ b/filter/converter.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var BasicOperatorMap = map[string]string{
+var basicOperatorMap = map[string]string{
 	"$gt":    ">",
 	"$gte":   ">=",
 	"$lt":    "<",
@@ -152,7 +152,7 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 						values = append(values, v[operator])
 					default:
 						value := v[operator]
-						op, ok := BasicOperatorMap[operator]
+						op, ok := basicOperatorMap[operator]
 						if !ok {
 							return "", nil, fmt.Errorf("unknown operator: %s", operator)
 						}


### PR DESCRIPTION
It's currently only exposed to make it possible to use it in a test. I don't think that's a good reason. It pollutes our API, and it's even weirder that users of the library would be able to modify it.