### PR TITLE
Make basicOperatorMap private

### DIFF
--- a/filter/converter.go
+++ b/filter/converter.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var BasicOperatorMap = map[string]string{
+var basicOperatorMap = map[string]string{
 	"$gt":    ">",
 	"$gte":   ">=",
 	"$lt":    "<",
@@ -152,7 +152,7 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 						values = append(values, v[operator])
 					default:
 						value := v[operator]
-						op, ok := BasicOperatorMap[operator]
+						op, ok := basicOperatorMap[operator]
 						if !ok {
 							return "", nil, fmt.Errorf("unknown operator: %s", operator)
 						}

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -335,19 +335,6 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			}
 		})
 	}
-
-	for op := range filter.BasicOperatorMap {
-		found := false
-		for _, tt := range tests {
-			if strings.Contains(tt.input, op) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("operator %q is not tested", op)
-		}
-	}
 }
 
 func TestIntegration_NestedJSONB(t *testing.T) {


### PR DESCRIPTION
It's currently only exposed to make it possible to use it in a test. I don't think that's a good reason. It pollutes our API, and it's even weirder that users of the library would be able to modify it.