### PR TITLE
Always return nil for empty values

### DIFF
--- a/filter/converter.go
+++ b/filter/converter.go
@@ -53,6 +53,10 @@ func (c *Converter) Convert(query []byte, startAtParameterIndex int) (conditions
 		return "", nil, fmt.Errorf("startAtParameterIndex must be greater than 0")
 	}
 
+	if len(query) == 0 {
+		return c.emptyCondition, nil, nil
+	}
+
 	var mongoFilter map[string]any
 	err = json.Unmarshal(query, &mongoFilter)
 	if err != nil {
@@ -60,7 +64,7 @@ func (c *Converter) Convert(query []byte, startAtParameterIndex int) (conditions
 	}
 
 	if len(mongoFilter) == 0 {
-		return c.emptyCondition, []any{}, nil
+		return c.emptyCondition, nil, nil
 	}
 
 	conditions, values, err = c.convertFilter(mongoFilter, startAtParameterIndex)

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -198,7 +198,7 @@ func TestConverter_Convert(t *testing.T) {
 			nil,
 			`{}`,
 			`FALSE`,
-			[]any{},
+			nil,
 			nil,
 		}, {
 			"empty or conditions",


### PR DESCRIPTION
Don't sometimes return []any{} instead. Keep the API consistent.