### PR TITLE
Plain comparison only works with primitives

### DIFF
--- a/filter/converter.go
+++ b/filter/converter.go
@@ -191,6 +191,9 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 				}
 				conditions = append(conditions, innerResult)
 			default:
+				if !isScalar(value) {
+					return "", nil, fmt.Errorf("invalid comparison value (must be a primitive): %v", value)
+				}
 				conditions = append(conditions, fmt.Sprintf("(%s = $%d)", c.columnName(key), paramIndex))
 				paramIndex++
 				values = append(values, value)

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -248,6 +248,22 @@ func TestConverter_Convert(t *testing.T) {
 			nil,
 			fmt.Errorf("invalid value for $not operator (must be object): John"),
 		},
+		{
+			"sql injection",
+			nil,
+			`{"\"bla = 1 --": 1}`,
+			``,
+			nil,
+			fmt.Errorf("invalid column name: \"bla = 1 --"),
+		},
+		{
+			"compare with array",
+			nil,
+			`{"items": [200, 300]}`,
+			``,
+			nil,
+			fmt.Errorf("invalid comparison value (must be a primitive): [200 300]"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -321,6 +321,12 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			[]int{3, 4, 5, 6, 7, 8, 9, 10},
 			nil,
 		},
+		{
+			"$gt with jsonb column",
+			`{"guild_id": { "$gt": 40 }}`,
+			[]int{7, 8, 9, 10},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Comparing with an array will result in an error.

I tried to see if I could implement comparison with an array, but that doesn't seem possible as you need to know the array type in postgres, which we don't.