### PR TITLE
Set converter defaults once in Convert method

### DIFF
--- a/filter/converter.go
+++ b/filter/converter.go
@@ -20,11 +20,12 @@ var basicOperatorMap = map[string]string{
 	"$regex": "~*",
 }
 
-// DefaultPlaceholderName is the default placeholder name used in the generated SQL query.
+// defaultPlaceholderName is the default placeholder name used in the generated SQL query.
 // This name should not be used in the database or any JSONB column. It can be changed using
 // the WithPlaceholderName option.
-const DefaultPlaceholderName = "__filter_placeholder"
+const defaultPlaceholderName = "__filter_placeholder"
 
+// Converter converts MongoDB filter queries to SQL conditions and values. Use [filter.NewConverter] to create a new instance.
 type Converter struct {
 	nestedColumn     string
 	nestedExemptions []string
@@ -38,9 +39,9 @@ type Converter struct {
 	once sync.Once
 }
 
-// NewConverter creates a new Converter with optional nested JSONB field mapping.
+// NewConverter creates a new [Converter] with optional nested JSONB field mapping.
 //
-// Note: When using github.com/lib/pq, the filter.WithArrayDriver should be set to pq.Array.
+// Note: When using https://github.com/lib/pq, the [filter.WithArrayDriver] should be set to pq.Array.
 func NewConverter(options ...Option) *Converter {
 	converter := &Converter{
 		// don't set defaults, use the once.Do in #Convert()
@@ -63,7 +64,7 @@ func (c *Converter) Convert(query []byte, startAtParameterIndex int) (conditions
 			c.emptyCondition = "FALSE"
 		}
 		if c.placeholderName == "" {
-			c.placeholderName = DefaultPlaceholderName
+			c.placeholderName = defaultPlaceholderName
 		}
 	})
 

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -402,3 +402,28 @@ func TestConverter_WithEmptyCondition(t *testing.T) {
 		t.Errorf("Converter.Convert() values = %v, want nil", values)
 	}
 }
+
+func TestConverter_NoConstructor(t *testing.T) {
+	c := &filter.Converter{}
+	conditions, values, err := c.Convert([]byte(`{"name": "John"}`), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `("name" = $1)`; conditions != want {
+		t.Errorf("Converter.Convert() conditions = %v, want %v", conditions, want)
+	}
+	if !reflect.DeepEqual(values, []any{"John"}) {
+		t.Errorf("Converter.Convert() values = %v, want %v", values, []any{"John"})
+	}
+
+	conditions, values, err = c.Convert([]byte(``), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "FALSE"; conditions != want {
+		t.Errorf("Converter.Convert() conditions = %v, want %v", conditions, want)
+	}
+	if len(values) != 0 {
+		t.Errorf("Converter.Convert() values = %v, want nil", values)
+	}
+}

--- a/filter/doc.go
+++ b/filter/doc.go
@@ -1,0 +1,5 @@
+// This package converts MongoDB query filters into PostgreSQL WHERE clauses.
+// It's designed to be simple, secure, and free of dependencies.
+//
+// See: https://www.mongodb.com/docs/compass/current/query/filter
+package filter


### PR DESCRIPTION
This will make the converter also work as expected when the filter.Converter struct is created without the NewConverter function.