### PR TITLE
Fix comparison of numeric jsonb columns

### DIFF
--- a/examples/readme_test.go
+++ b/examples/readme_test.go
@@ -33,6 +33,6 @@ func ExampleNewConverter_readme() {
 	fmt.Println(conditions)
 	fmt.Printf("%#v\n", values)
 	// Output:
-	// ((("meta"->>'map' ~* $1) OR ("meta"->>'map' ~* $2)) AND ("meta"->>'password' = $3) AND (("meta"->>'playerCount' >= $4) AND ("meta"->>'playerCount' < $5)))
+	// ((("meta"->>'map' ~* $1) OR ("meta"->>'map' ~* $2)) AND ("meta"->>'password' = $3) AND ((("meta"->>'playerCount')::numeric >= $4) AND (("meta"->>'playerCount')::numeric < $5)))
 	// []interface {}{"aztec", "nuke", "", 2, 10}
 }

--- a/filter/converter.go
+++ b/filter/converter.go
@@ -237,26 +237,22 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 						values = append(values, innerValues...)
 					default:
 						value := v[operator]
-						isNumericOperatorMap := false
+						isNumericOperator := false
 						op, ok := textOperatorMap[operator]
 						if !ok {
 							op, ok = numericOperatorMap[operator]
 							if !ok {
 								return "", nil, fmt.Errorf("unknown operator: %s", operator)
 							}
-							isNumericOperatorMap = true
+							isNumericOperator = true
 						}
 
 						if !isScalar(value) {
 							return "", nil, fmt.Errorf("invalid comparison value (must be a primitive): %v", value)
 						}
 
-						if isNumericOperatorMap && isNumeric(value) {
-							if c.isNestedColumn(key) {
-								inner = append(inner, fmt.Sprintf("((%s)::numeric %s $%d)", c.columnName(key), op, paramIndex))
-							} else {
-								inner = append(inner, fmt.Sprintf("(%s %s $%d)", c.columnName(key), op, paramIndex))
-							}
+						if isNumericOperator && isNumeric(value) && c.isNestedColumn(key) {
+							inner = append(inner, fmt.Sprintf("((%s)::numeric %s $%d)", c.columnName(key), op, paramIndex))
 						} else {
 							inner = append(inner, fmt.Sprintf("(%s %s $%d)", c.columnName(key), op, paramIndex))
 						}

--- a/filter/converter.go
+++ b/filter/converter.go
@@ -247,6 +247,8 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 							isNumericOperator = true
 						}
 
+						// Prevent cryptic errors like:
+						// 	 unexpected error: sql: converting argument $1 type: unsupported type []interface {}, a slice of interface
 						if !isScalar(value) {
 							return "", nil, fmt.Errorf("invalid comparison value (must be a primitive): %v", value)
 						}
@@ -281,6 +283,8 @@ func (c *Converter) convertFilter(filter map[string]any, paramIndex int) (string
 					conditions = append(conditions, fmt.Sprintf("(%s IS NULL)", c.columnName(key)))
 				}
 			default:
+				// Prevent cryptic errors like:
+				// 	 unexpected error: sql: converting argument $1 type: unsupported type []interface {}, a slice of interface
 				if !isScalar(value) {
 					return "", nil, fmt.Errorf("invalid comparison value (must be a primitive): %v", value)
 				}

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -358,6 +358,14 @@ func TestConverter_Convert(t *testing.T) {
 			[]any{float64(18)},
 			nil,
 		},
+		{
+			"numeric comparison bug with jsonb column",
+			filter.WithNestedJSONB("meta"),
+			`{"foo": {"$gt": 0}}`,
+			`(("meta"->>'foo')::numeric > $1)`,
+			[]any{float64(0)},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -374,6 +374,14 @@ func TestConverter_Convert(t *testing.T) {
 			[]any{nil},
 			nil,
 		},
+		{
+			"compare with non scalar",
+			nil,
+			`{"name": {"$eq": [1, 2]}}`,
+			``,
+			nil,
+			fmt.Errorf("invalid comparison value (must be a primitive): [1 2]"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/filter/converter_test.go
+++ b/filter/converter_test.go
@@ -366,6 +366,14 @@ func TestConverter_Convert(t *testing.T) {
 			[]any{float64(0)},
 			nil,
 		},
+		{
+			"numeric comparison against null with jsonb column",
+			filter.WithNestedJSONB("meta"),
+			`{"foo": {"$gt": null}}`,
+			`("meta"->>'foo' > $1)`,
+			[]any{nil},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/filter/util.go
+++ b/filter/util.go
@@ -1,16 +1,10 @@
 package filter
 
 func isNumeric(v any) bool {
-	if v == nil {
-		return true
-	}
-
-	switch v.(type) {
-	case float64:
-		return true
-	default:
-		return false
-	}
+	// json.Unmarshal returns float64 for all numbers
+	// so we only need to check for float64.
+	_, ok := v.(float64)
+	return ok
 }
 
 func isScalar(v any) bool {

--- a/filter/util.go
+++ b/filter/util.go
@@ -1,5 +1,18 @@
 package filter
 
+func isNumeric(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	switch v.(type) {
+	case float64:
+		return true
+	default:
+		return false
+	}
+}
+
 func isScalar(v any) bool {
 	if v == nil {
 		return true

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -286,13 +286,13 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			nil,
 		},
 		{
-			`invalid value type 1`,
+			`invalid value type int`,
 			`{"level": "town1"}`, // Level is an integer column, but the value is a string.
 			nil,
 			errors.New(`pq: invalid input syntax for type integer: "town1"`),
 		},
 		{
-			`invalid value type 2`,
+			`invalid value type string`,
 			`{"name": 123}`, // Name is a string column, but the value is an integer.
 			[]int{},
 			nil,
@@ -388,9 +388,15 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			nil,
 		},
 		{
-			"numeric comparison bug bug with jsonb column",
+			`$lt bug with jsonb column`,
 			`{"guild_id": {"$lt": 100}}`,
-			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // wrong
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			nil,
+		},
+		{
+			`$lt with null and jsonb column`,
+			`{"guild_id": {"$lt": null}}`,
+			[]int{},
 			nil,
 		},
 	}

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -286,10 +286,16 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			nil,
 		},
 		{
-			`invalid value`,
+			`invalid value type 1`,
 			`{"level": "town1"}`, // Level is an integer column, but the value is a string.
 			nil,
-			errors.New("pq: invalid input syntax for type integer: \"town1\""),
+			errors.New(`pq: invalid input syntax for type integer: "town1"`),
+		},
+		{
+			`invalid value type 2`,
+			`{"name": 123}`, // Name is a string column, but the value is an integer.
+			[]int{},
+			nil,
 		},
 		{
 			`empty object`,
@@ -379,6 +385,12 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			"$elemMatch with numeric jsonb column",
 			`{"keys": {"$elemMatch": {"$gt": 5}}}`,
 			[]int{3},
+			nil,
+		},
+		{
+			"numeric comparison bug bug with jsonb column",
+			`{"guild_id": {"$lt": 100}}`,
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // wrong
 			nil,
 		},
 	}

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -388,13 +388,13 @@ func TestIntegration_BasicOperators(t *testing.T) {
 			nil,
 		},
 		{
-			`$lt bug with jsonb column`,
+			"$lt bug with jsonb column",
 			`{"guild_id": {"$lt": 100}}`,
 			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			nil,
 		},
 		{
-			`$lt with null and jsonb column`,
+			"$lt with null and jsonb column",
 			`{"guild_id": {"$lt": null}}`,
 			[]int{},
 			nil,


### PR DESCRIPTION
Since we use `->>` on `jsonb` fields we always get a string back. Comparisons such as `<` and `>` were done on string values which gives unexpected results.

I have tried various other approaches that failed.
- Casting everything to a `jsonb` doesn't work because you can't cast query params to `jsonb`.
- Using a `CASE WHEN` with `jsonb_typeof` doesn't work because each `WHEN` of a `CASE WHEN` needs to return the same type.
- There are also complications with calling `Convert` recursively for `$elemMatch` where you then don't know the column type anymore.