### PR TITLE
Delay dependabot updates by 5 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -16,3 +18,5 @@ updates:
       gomod:
         patterns:
           - "*"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
Wait 5 days to get updates. We hope supply chain attacks are detected before these 5 days.