### PR TITLE
Add new Github Action workflow to run govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,18 @@
+name: govulncheck
+on:
+  pull_request:
+  schedule:
+    - cron: '22 10 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - run: |
+          go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
This so we can disable Dependabot on this project, that will generate more false positives (the latest notification was not relevant to this project).
We can also keep both enabled.